### PR TITLE
ignore jquery.js in gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ const gap = require('gulp-append-prepend');
 gulp.task('licenses', function (done) {
   // this is to add ChongLuaDao licenses in the production mode for the minified js
   gulp
-    .src(['!build/js/jquery.js', 'build/js/*js'], {base: './'})
+    .src(['build/js/*js', '!build/js/jquery.js'], {base: './'})
     .pipe(
       gap.prependText(`/*!
 


### PR DESCRIPTION
@dshongphuc this was a mistake, ignored js have to be mentioned later. 